### PR TITLE
Removing redundant names from libs.version.toml

### DIFF
--- a/src/jsMain/kotlin/Main.kt
+++ b/src/jsMain/kotlin/Main.kt
@@ -29,7 +29,6 @@ sealed interface Lib {
             nameHyphenation = nameStrArray.filterIndexed { _, s ->
                 !groupStrArray.contains(s)
             }.joinToString("-")
-            console.log("group: $groupHyphenation name: $nameHyphenation")
             val lastSubstring = groupHyphenation.substring(
                 groupHyphenation.length - nameHyphenation.length,
                 groupHyphenation.length


### PR DESCRIPTION
What does this pull-request change?

1. Remove the extra name from `.toml` to make it more readable when importing.

before:
> androidx-compose-ui-ui-util = { module = "androidx.compose.ui:ui-util", version.ref = "androidxComposeUi" }
> implementation(libs.androidx.compose.ui.ui.util)

now:
> androidx-compose-ui-util = { module = "androidx.compose.ui:ui-util", version.ref = "androidxComposeUi" }
>implementation(libs.androidx.compose.ui.util)

2. Added the result of build.gradle.kts and added the implemtation prefix for easy replication.

![image](https://user-images.githubusercontent.com/31311826/174202743-73a46305-98fb-4607-aeec-c4b4ee72ac3a.png)

But this seems a bit wrong because some package names are `debugImplementation`, `androidTestImplementation`, `testImplementation`, etc. 🤔